### PR TITLE
fix: correctly reconcile state [GTN-2137]

### DIFF
--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,7 +1,7 @@
 import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
 import logger from 'redux-logger';
 import { FLUSH, PAUSE, PERSIST, persistReducer, persistStore, PURGE, REGISTER, REHYDRATE } from 'redux-persist';
-import hardSet from 'redux-persist/lib/stateReconciler/hardSet';
+import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import { localStorage } from 'redux-persist-webextension-storage';
 
 import rootReducer, { AppReducer, RootState } from './rootReducer';
@@ -13,7 +13,7 @@ const persistConfig = {
   storage: localStorage,
   version: 1,
   blacklist: ['status'],
-  stateReconciler: hardSet
+  stateReconciler: autoMergeLevel2
 };
 
 const persistedReducer = persistReducer<RootState>(persistConfig, rootReducer);


### PR DESCRIPTION
The issue with selecting a newly introduced network is that, in runtime, it does not exist in the state as the various parts of the wallet require it to be. This is because currently redux-persist rehydrates the state and resets it to its previous state — without the new network.

Using `autoMergeLevel2` to reconcile state fixes this issue, as it allows for merging the new network as a key in the appropriate states, instead of resetting it to its previous state on rehydrate.