### PR TITLE
Fix Account and Network Unsubscribing

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@polkadot/x-fetch": "^10.4.2",
     "babel-core": "^7.0.0-bridge.0",
     "safe-buffer": "^5.2.1",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "rxjs": "^7.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "@polkadot/util-crypto": "^10.4.2",
     "@polkadot/x-fetch": "^10.4.2",
     "babel-core": "^7.0.0-bridge.0",
+    "rxjs": "^7.8.0",
     "safe-buffer": "^5.2.1",
-    "typescript": "^4.4.4",
-    "rxjs": "^7.8.0"
+    "typescript": "^4.4.4"
   }
 }

--- a/packages/core/src/background/types.ts
+++ b/packages/core/src/background/types.ts
@@ -38,6 +38,10 @@ export type RequestPolyIsDevSubscribe = null;
 
 export type RequestPolyIsPasswordSet = null;
 
+export interface RequestPolyAccountUnsubscribe {
+  id: string;
+}
+
 export interface RequestPolyNetworkSet {
   network: NetworkName;
 }

--- a/packages/core/src/background/types.ts
+++ b/packages/core/src/background/types.ts
@@ -42,6 +42,10 @@ export interface RequestPolyAccountUnsubscribe {
   id: string;
 }
 
+export interface RequestPolyNetworkUnsubscribe {
+  id: string;
+}
+
 export interface RequestPolyNetworkSet {
   network: NetworkName;
 }
@@ -119,9 +123,10 @@ export interface PolyRequestSignatures extends DotRequestSignatures {
   'poly:pub(network.get)': [RequestPolyNetworkGet, NetworkMeta];
   'poly:pub(network.subscribe)': [
     RequestPolyNetworkMetaSubscribe,
-    boolean,
+    string,
     NetworkMeta
   ];
+  'poly:pub(network.unsubscribe)': [RequestPolyNetworkUnsubscribe, boolean];
 }
 
 declare type IsNull<T, K extends keyof T> = {

--- a/packages/core/src/page/Network.ts
+++ b/packages/core/src/page/Network.ts
@@ -16,12 +16,19 @@ export default class Network implements InjectedNetwork {
   }
 
   public subscribe(cb: (networkMeta: NetworkMeta) => unknown): Unsubcall {
-    sendRequest('poly:pub(network.subscribe)', null, cb).catch((error: Error) =>
-      console.error(error)
-    );
+    let id: string | null = null;
+
+    sendRequest('poly:pub(network.subscribe)', null, cb)
+      .then((subId): void => {
+        id = subId;
+      })
+      .catch(console.error);
 
     return (): void => {
-      // FIXME we need the ability to unsubscribe
+      id &&
+        sendRequest('poly:pub(network.unsubscribe)', { id }).catch(
+          console.error
+        );
     };
   }
 }

--- a/packages/ui/src/styles/utils.ts
+++ b/packages/ui/src/styles/utils.ts
@@ -73,6 +73,9 @@ export const visuallyHidden: Styles = () => ({
   border: 0,
 });
 
-export function hasKey<O>(obj: O, key: keyof any): key is keyof O {
+export function hasKey<O extends object>(
+  obj: O,
+  key: keyof any
+): key is keyof O {
   return key in obj;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13889,21 +13889,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@6:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^7.5.5, rxjs@^7.5.6:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
-  integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
-  dependencies:
-    tslib "^2.1.0"
-
-rxjs@^7.8.0:
+rxjs@6, rxjs@^7.5.5, rxjs@^7.5.6, rxjs@^7.8.0:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
@@ -15223,7 +15209,7 @@ tsconfig-paths@^3.10.1, tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
- Add the ability to unsubscribe from `accounts`.
- Add the ability to unsubscribe from `network` information.
- `accounts.subscribe` now returns account details on initial subscription. This is in line with other polkadot extension based wallets.
- `network.subscribe` now returns network details on initial subscription.

The implementation of the subs & unsubs uses a similar approach to the polkadot/extension-base methods which are overridden for accounts by the polymesh/extension-core https://github.com/polkadot-js/extension/blob/3c35c2bcd5b5c4657fb597915d86368b1386994c/packages/extension-base/src/background/handlers/Tabs.ts#L79