### PR TITLE
Improve flow for troubleshooting Ledger connection and misc other changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.0.1](https://github.com/PolymeshAssociation/polymesh-wallet/compare/2.0.0...2.0.1) (2024-08-27)
+
+
+### Bug Fixes
+
+* update bump-versions.sh to work with yarn@4.4.0 ([7e32b13](https://github.com/PolymeshAssociation/polymesh-wallet/commit/7e32b13e369e1ab684b72fb4e57c09b4680d148d))
+
 # [2.0.0](https://github.com/PolymeshAssociation/polymesh-wallet/compare/1.8.3...2.0.0) (2024-08-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.0.2](https://github.com/PolymeshAssociation/polymesh-wallet/compare/2.0.1...2.0.2) (2024-08-28)
+
+
+### Bug Fixes
+
+* update README ([c9f101d](https://github.com/PolymeshAssociation/polymesh-wallet/commit/c9f101d8d4f2173eb2a110cb5f318b34109861ed))
+
 ## [2.0.1](https://github.com/PolymeshAssociation/polymesh-wallet/compare/2.0.0...2.0.1) (2024-08-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.0.3](https://github.com/PolymeshAssociation/polymesh-wallet/compare/2.0.2...2.0.3) (2024-08-28)
+
+
+### Bug Fixes
+
+* store did key addresses in the default SS58 format used by the keyring ([7f1425a](https://github.com/PolymeshAssociation/polymesh-wallet/commit/7f1425aaba1a24906ed6f4bc09376cd73a7933c4))
+
 ## [2.0.2](https://github.com/PolymeshAssociation/polymesh-wallet/compare/2.0.1...2.0.2) (2024-08-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# [2.0.0](https://github.com/PolymeshAssociation/polymesh-wallet/compare/1.8.3...2.0.0) (2024-08-27)
+
+
+### Bug Fixes
+
+* enable corepack ([f8a0391](https://github.com/PolymeshAssociation/polymesh-wallet/commit/f8a03918b368d331555a463f0fca6720356ec13a))
+
+
+### Features
+
+* migrate to Manifest V3 and align with upstream polkadot extension ([5d7198d](https://github.com/PolymeshAssociation/polymesh-wallet/commit/5d7198dc97874bb28089ada602b85d7944ed8774))
+
+
+### BREAKING CHANGES
+
+* Updated Polymesh wallet to support Manifest V3, with significant updates aligning configurations, dependencies, and architecture to match upstream polkadot wallet. This may affect compatibility with environments relying on Manifest V2.
+
 ## [1.8.3](https://github.com/PolymeshAssociation/polymesh-wallet/compare/1.8.2...1.8.3) (2024-04-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [2.1.0](https://github.com/PolymeshAssociation/polymesh-wallet/compare/2.0.3...2.1.0) (2024-10-23)
+
+
+### Bug Fixes
+
+* update github action ([0b0e40d](https://github.com/PolymeshAssociation/polymesh-wallet/commit/0b0e40df2bb95f9a2de20b0b355e6ee607926a86))
+* use github actions/upload-artifact@v4 ([e57751e](https://github.com/PolymeshAssociation/polymesh-wallet/commit/e57751ead548b8cfeb36563f168e7235789c6ec6))
+
+
+### Features
+
+* add dual compatibility with polymesh v6 and v7 ([e51f12d](https://github.com/PolymeshAssociation/polymesh-wallet/commit/e51f12d3d2271e428353dd6191ebeb76d4dd3b50))
+
 ## [2.0.3](https://github.com/PolymeshAssociation/polymesh-wallet/compare/2.0.2...2.0.3) (2024-08-28)
 
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Besides the [API interface](https://github.com/polkadot-js/extension) of Polkado
 
 ```js
 enum NetworkName {
-  pmf = 'pmf',
-  alcyone = 'alcyone',
-  pme = 'pme',
-  local = 'local'
-  itn = 'itn'
+  mainnet = "mainnet",
+  testnet = "testnet",
+  staging = "staging",
+  local = "local",
+  custom = "custom"
 }
 
 type NetworkMeta = {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "1.8.3",
+  "version": "2.0.0",
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@polkadot/dev": "^0.79.3",
     "@polkadot/dev-test": "^0.79.3",
     "@polkadot/types": "^12.3.1",
-    "@polymeshassociation/polymesh-sdk": "^26.0.0-beta.2",
+    "@polymeshassociation/polymesh-sdk": "^27.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymeshassociation/extension-core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymeshassociation/extension-core",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymeshassociation/extension-core",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymeshassociation/extension-core",
-  "version": "1.8.3",
+  "version": "2.0.1",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,9 +10,10 @@
   "author": "",
   "license": "Apache-2",
   "dependencies": {
-    "@polkadot/api-augment": "^12.3.1",
+    "@polkadot/api-augment": "12.3.1",
+    "@polkadot/types-codec": "12.3.1",
     "@polkadot/ui-keyring": "^3.8.3",
-    "@polymeshassociation/polymesh-types": "^5.11.1",
+    "@polymeshassociation/polymesh-types": "^5.15.0",
     "@reduxjs/toolkit": "^1.9.7",
     "crypto-js": "^4.2.0",
     "lodash": "^4.17.21",

--- a/packages/core/src/external/callDetails.ts
+++ b/packages/core/src/external/callDetails.ts
@@ -1,7 +1,9 @@
 import type { Call } from '@polkadot/types/interfaces';
-import type { AnyJson, SignerPayloadJSON } from '@polkadot/types/types';
+import type { AnyJson, Codec, SignerPayloadJSON } from '@polkadot/types/types';
+import type { Enum } from '@polkadot/types-codec';
 import type { ResponsePolyCallDetails } from '@polymeshassociation/extension-core/background/types';
 
+import { Vec } from '@polkadot/types-codec';
 import { upperFirst } from 'lodash-es';
 
 import apiPromise from './apiPromise';
@@ -18,11 +20,59 @@ async function callDetails (
   const humanArgs: AnyJson = (call.toHuman() as { args: AnyJson }).args;
   const { args, meta, method, section } = call;
 
+  // Helper function to check if a value is a Call
+  function isCall (value: Codec): value is Call {
+    return 'callIndex' in value && 'argsEntries' in value;
+  }
+
+  // Helper function to check if a value is a Vec
+  function isVec (value: Codec): value is Vec<Codec> {
+    return value instanceof Vec;
+  }
+
+  // Helper function to calculate protocol fee
+  async function calculateProtocolFee (call: Call): Promise<string> {
+    let totalProtocolFee = '0';
+    const { method, section } = call;
+    let opName = upperFirst(section) + upperFirst(method);
+
+    const protocolFeeOpEnum: Enum = api.registry.createType('PolymeshCommonUtilitiesProtocolFeeProtocolOp');
+
+    // TODO: Remove once AssetRegisterUniqueTicker is added to PolymeshCommonUtilitiesProtocolFeeProtocolOp
+    if (opName === 'AssetRegisterUniqueTicker') {
+      if (!protocolFeeOpEnum.defKeys.includes(opName)) {
+        opName = 'AssetRegisterTicker';
+      }
+    }
+
+    if (protocolFeeOpEnum.defKeys.includes(opName)) {
+      const fee = (await api.query.protocolFee.baseFees(opName)).toString();
+
+      totalProtocolFee = (BigInt(totalProtocolFee) + BigInt(fee)).toString();
+    }
+
+    async function processArg (arg: Codec): Promise<void> {
+      if (isVec(arg)) {
+        for (const nestedArg of arg) {
+          await processArg(nestedArg);
+        }
+      } else if (isCall(arg)) {
+        const nestedFee = await calculateProtocolFee(arg);
+
+        totalProtocolFee = (BigInt(totalProtocolFee) + BigInt(nestedFee)).toString();
+      }
+    }
+
+    for (const [_, arg] of call.argsEntries) {
+      await processArg(arg);
+    }
+
+    return totalProtocolFee;
+  }
+
   // Protocol fee
   try {
-    const opName = upperFirst(section) + upperFirst(method);
-
-    protocolFee = (await api.query.protocolFee.baseFees(opName)).toString();
+    protocolFee = await calculateProtocolFee(call);
   } catch (error) {
     console.log(
       `Error: Protocol fee retrieval for method ${section}:${method} has failed`,

--- a/packages/core/src/page/injected.ts
+++ b/packages/core/src/page/injected.ts
@@ -1,16 +1,25 @@
+import type { Injected } from '@polkadot/extension-inject/types';
 import type { SendRequest } from '@polymeshassociation/extension-core/page/types';
 
-import Injected from '@polkadot/extension-base/page/Injected';
+import Accounts from '@polkadot/extension-base/page/Accounts';
+import Metadata from '@polkadot/extension-base/page/Metadata';
+import PostMessageProvider from '@polkadot/extension-base/page/PostMessageProvider';
+import Signer from '@polkadot/extension-base/page/Signer';
 
 import Network from './Network';
 
-class PolymeshInjected extends Injected {
+export default class PolymeshInjected implements Injected {
+  public readonly accounts: Accounts;
+  public readonly metadata: Metadata;
   public readonly network: Network;
+  public readonly provider: PostMessageProvider;
+  public readonly signer: Signer;
 
   constructor (sendRequest: SendRequest) {
-    super(sendRequest);
+    this.accounts = new Accounts(sendRequest);
+    this.metadata = new Metadata(sendRequest);
     this.network = new Network(sendRequest);
+    this.provider = new PostMessageProvider(sendRequest);
+    this.signer = new Signer(sendRequest);
   }
 }
-
-export default PolymeshInjected;

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -15,14 +15,14 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "1.8.3",
+  "version": "2.0.1",
   "dependencies": {
     "@polkadot/api": "^12.3.1",
     "@polkadot/extension-base": "^0.51.1",
     "@polkadot/extension-inject": "^0.51.1",
     "@polkadot/ui-keyring": "^3.8.3",
-    "@polymeshassociation/extension-core": "1.8.3",
-    "@polymeshassociation/extension-ui": "1.8.3",
+    "@polymeshassociation/extension-core": "2.0.1",
+    "@polymeshassociation/extension-ui": "2.0.1",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -15,14 +15,14 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "dependencies": {
     "@polkadot/api": "^12.3.1",
     "@polkadot/extension-base": "^0.51.1",
     "@polkadot/extension-inject": "^0.51.1",
     "@polkadot/ui-keyring": "^3.8.3",
-    "@polymeshassociation/extension-core": "2.0.3",
-    "@polymeshassociation/extension-ui": "2.0.3",
+    "@polymeshassociation/extension-core": "2.1.0",
+    "@polymeshassociation/extension-ui": "2.1.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -15,14 +15,14 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "dependencies": {
     "@polkadot/api": "^12.3.1",
     "@polkadot/extension-base": "^0.51.1",
     "@polkadot/extension-inject": "^0.51.1",
     "@polkadot/ui-keyring": "^3.8.3",
-    "@polymeshassociation/extension-core": "2.0.2",
-    "@polymeshassociation/extension-ui": "2.0.2",
+    "@polymeshassociation/extension-core": "2.0.3",
+    "@polymeshassociation/extension-ui": "2.0.3",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -15,14 +15,14 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "dependencies": {
     "@polkadot/api": "^12.3.1",
     "@polkadot/extension-base": "^0.51.1",
     "@polkadot/extension-inject": "^0.51.1",
     "@polkadot/ui-keyring": "^3.8.3",
-    "@polymeshassociation/extension-core": "2.0.1",
-    "@polymeshassociation/extension-ui": "2.0.1",
+    "@polymeshassociation/extension-core": "2.0.2",
+    "@polymeshassociation/extension-ui": "2.0.2",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymeshassociation/extension-ui",
   "description": "A sample signer extension for the @polkadot/api",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "license": "Apache-2",
   "type": "module",
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymeshassociation/extension-ui",
   "description": "A sample signer extension for the @polkadot/api",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "Apache-2",
   "type": "module",
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymeshassociation/extension-ui",
   "description": "A sample signer extension for the @polkadot/api",
-  "version": "1.8.3",
+  "version": "2.0.1",
   "license": "Apache-2",
   "type": "module",
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymeshassociation/extension-ui",
   "description": "A sample signer extension for the @polkadot/api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2",
   "type": "module",
   "dependencies": {

--- a/packages/ui/src/Popup/Signing/LedgerSignArea.tsx
+++ b/packages/ui/src/Popup/Signing/LedgerSignArea.tsx
@@ -3,10 +3,11 @@ import type { ExtrinsicPayload } from '@polkadot/types/interfaces';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 
 import { ActionContext, Warning } from '@polymeshassociation/extension-ui/components';
+import useIsPopup from '@polymeshassociation/extension-ui/hooks/useIsPopup';
+import { cancelSignRequest, windowOpen } from '@polymeshassociation/extension-ui/messaging';
 import { Button, Flex } from '@polymeshassociation/extension-ui/ui';
 
 import { Status, useLedger } from '../../hooks/useLedger';
-import { cancelSignRequest } from '../../messaging';
 
 interface Props {
   accountIndex?: number;
@@ -35,11 +36,17 @@ function LedgerSignArea ({ accountIndex,
     refresh,
     status: ledgerStatus } = useLedger(genesisHash, accountIndex, addressOffset);
   const onAction = useContext(ActionContext);
+  const isPopup = useIsPopup();
 
-  const _onRefresh = useCallback(() => {
-    refresh();
-    setError(null);
-  }, [refresh, setError]);
+  const _onRefresh = useCallback(async () => {
+    if (isPopup && ledgerStatus === Status.Device) {
+      await windowOpen('/').catch(console.error);
+      window.close();
+    } else {
+      refresh();
+      setError(null);
+    }
+  }, [isPopup, ledgerStatus, refresh, setError]);
 
   const _onSignLedger = useCallback((): void => {
     if (!ledger || !payload || !onSignature) {
@@ -68,7 +75,9 @@ function LedgerSignArea ({ accountIndex,
 
   const warning = useMemo(() => {
     if (ledgerStatus === Status.Device) {
-      return 'Please make sure that Ledger device is plugged and unlocked';
+      return isPopup
+        ? 'Please ensure your Ledger device is plugged in and unlocked. Then go full screen and click the connect button to connect your device.'
+        : 'Please ensure your Ledger device is plugged in and unlocked. Then click the connect button.';
     } else if (ledgerStatus === Status.App) {
       return 'Please make sure that Ledger Polymesh App is installed on your device, and is open.';
     } else if (ledgerStatus === Status.Pending) {
@@ -80,7 +89,23 @@ function LedgerSignArea ({ accountIndex,
     } else {
       return null;
     }
-  }, [ledgerStatus, ledgerError]);
+  }, [ledgerStatus, ledgerError, isPopup]);
+
+  const buttonLabel = useMemo(() => {
+    if (warning) {
+      if (isPopup && ledgerStatus === Status.Device) {
+        return 'Open Full Screen';
+      }
+
+      if (ledgerStatus === Status.Device) {
+        return 'Connect';
+      }
+
+      return 'Refresh';
+    }
+
+    return 'Sign on Ledger';
+  }, [isPopup, ledgerStatus, warning]);
 
   return (
     <Flex
@@ -108,26 +133,14 @@ function LedgerSignArea ({ accountIndex,
           flex={1}
           ml='xs'
         >
-          {warning
-            ? (
-              <Button
-                busy={isBusy || ledgerLoading}
-                fluid
-                onClick={_onRefresh}
-                type='submit'
-              >
-                {'Refresh'}
-              </Button>
-            )
-            : (
-              <Button
-                busy={isBusy || ledgerLoading}
-                fluid
-                onClick={_onSignLedger}
-              >
-                {'Sign on Ledger'}
-              </Button>
-            )}
+          <Button
+            busy={isBusy || ledgerLoading}
+            fluid
+            onClick={warning ? _onRefresh : _onSignLedger}
+            type={warning ? 'submit' : undefined}
+          >
+            {buttonLabel}
+          </Button>
         </Flex>
       </Flex>
     </Flex>

--- a/packages/ui/src/Popup/Signing/Request.tsx
+++ b/packages/ui/src/Popup/Signing/Request.tsx
@@ -7,6 +7,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { Box, Heading } from '@polymeshassociation/extension-ui/ui';
+import polymeshSignedExtensions from '@polymeshassociation/polymesh-types/signedExtensions';
 
 import { ActionContext, VerticalSpace } from '../../components';
 import { approveSignSignature } from '../../messaging';
@@ -61,7 +62,7 @@ export default function Request ({ account: { accountIndex, addressOffset, isExt
       });
     } else {
       try {
-        registry.setSignedExtensions(payload.signedExtensions);
+        registry.setSignedExtensions(payload.signedExtensions, polymeshSignedExtensions);
 
         setData({
           hexBytes: null,

--- a/packages/ui/src/hooks/useLedger.ts
+++ b/packages/ui/src/hooks/useLedger.ts
@@ -164,9 +164,19 @@ export function useLedger (
           ? 'Is your ledger locked?'
           : null;
 
-        const errorMessage = e.message.includes('App does not seem to be open')
-          ? `App ${network} does not seem to be open`
-          : e.message;
+        let errorMessage;
+
+        switch (true) {
+          case e.message.includes('Code: 26628'):
+          case e.message.includes('Code: 21781'):
+            errorMessage = 'Ensure your device is unlocked';
+            break;
+          case e.message.includes('App does not seem to be open'):
+            errorMessage = `App ${network} does not seem to be open`;
+            break;
+          default:
+            errorMessage = e.message;
+        }
 
         setIsLocked(true);
         setWarning(warningMessage);

--- a/packages/ui/src/ui/Loading/Loading.tsx
+++ b/packages/ui/src/ui/Loading/Loading.tsx
@@ -6,9 +6,6 @@ import * as sc from './styles';
 
 export const Loading = (props: LoadingProps) => {
   return (
-    <sc.Wrapper {...props}>
-      <span />
-      <span />
-    </sc.Wrapper>
+    <sc.Wrapper {...props} />
   );
 };

--- a/packages/ui/src/ui/Loading/styles.ts
+++ b/packages/ui/src/ui/Loading/styles.ts
@@ -4,65 +4,20 @@ import type { LoadingProps } from './types';
 import styled, { keyframes } from 'styled-components';
 
 const spin = keyframes`
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(359deg);
-  }
-`;
-
-const mask = keyframes`
-  0% {
-    transform: rotate(0deg);
-  }
-  25% {
-    transform: rotate(180deg);
-  }
-  50% {
-    transform: rotate(180deg);
-  }
-  75% {
-    transform: rotate(360deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
+from {
+  transform: rotate(0deg);
+}
+to {
+  transform: rotate(360deg);
+}
 `;
 
 export const Wrapper = styled.div<LoadingProps>`
   position: relative;
   width: ${({ small }) => (small ? '18px' : '64px')};
   height: ${({ small }) => (small ? '18px' : '64px')};
-  animation: 1s ${spin} infinite cubic-bezier(0.255, 0.2, 0.315, 0.455);
-  span,
-  span:before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: ${({ small }) => (small ? '9px' : '32px')};
-    height: ${({ small }) => (small ? '18px' : '64px')};
-    overflow: hidden;
-    box-sizing: border-box;
-    transform-origin: 100% 50%;
-    border-top-left-radius: 32px;
-    border-bottom-left-radius: 32px;
-  }
-  span:before {
-    content: '';
-    border-width: ${({ small }) => (small ? '2px' : '5px')};
-    border-color: ${({ theme }: ThemeProps) => theme.colors.primary};
-    border-style: solid;
-    border-right-color: transparent;
-    animation: 4s ${mask} infinite linear;
-  }
-  span:nth-child(1) {
-    transform: rotate(180deg);
-  }
-  span:nth-child(2) {
-    transform: rotate(360deg);
-    &:before {
-      animation-delay: 1s;
-    }
-  }
+  border: ${({ small }) => (small ? '2px' : '5px')} solid ${({ theme }: ThemeProps) => theme.colors.primary};
+  border-radius: 50%;
+  border-top-color: transparent;
+  animation: ${spin} 1s cubic-bezier(0.255, 0.2, 0.315, 0.455) infinite;   
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,7 +2167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polymeshassociation/extension-core@npm:2.0.2, @polymeshassociation/extension-core@workspace:packages/core":
+"@polymeshassociation/extension-core@npm:2.0.3, @polymeshassociation/extension-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@polymeshassociation/extension-core@workspace:packages/core"
   dependencies:
@@ -2192,7 +2192,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polymeshassociation/extension-ui@npm:2.0.2, @polymeshassociation/extension-ui@workspace:packages/ui":
+"@polymeshassociation/extension-ui@npm:2.0.3, @polymeshassociation/extension-ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@polymeshassociation/extension-ui@workspace:packages/ui"
   dependencies:
@@ -2246,8 +2246,8 @@ __metadata:
     "@polkadot/extension-base": "npm:^0.51.1"
     "@polkadot/extension-inject": "npm:^0.51.1"
     "@polkadot/ui-keyring": "npm:^3.8.3"
-    "@polymeshassociation/extension-core": "npm:2.0.2"
-    "@polymeshassociation/extension-ui": "npm:2.0.2"
+    "@polymeshassociation/extension-core": "npm:2.0.3"
+    "@polymeshassociation/extension-ui": "npm:2.0.3"
     browser-resolve: "npm:^2.0.0"
     buffer: "npm:^6.0.3"
     copy-webpack-plugin: "npm:^11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,7 +2167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polymeshassociation/extension-core@npm:2.0.3, @polymeshassociation/extension-core@workspace:packages/core":
+"@polymeshassociation/extension-core@npm:2.1.0, @polymeshassociation/extension-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@polymeshassociation/extension-core@workspace:packages/core"
   dependencies:
@@ -2192,7 +2192,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polymeshassociation/extension-ui@npm:2.0.3, @polymeshassociation/extension-ui@workspace:packages/ui":
+"@polymeshassociation/extension-ui@npm:2.1.0, @polymeshassociation/extension-ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@polymeshassociation/extension-ui@workspace:packages/ui"
   dependencies:
@@ -2246,8 +2246,8 @@ __metadata:
     "@polkadot/extension-base": "npm:^0.51.1"
     "@polkadot/extension-inject": "npm:^0.51.1"
     "@polkadot/ui-keyring": "npm:^3.8.3"
-    "@polymeshassociation/extension-core": "npm:2.0.3"
-    "@polymeshassociation/extension-ui": "npm:2.0.3"
+    "@polymeshassociation/extension-core": "npm:2.1.0"
+    "@polymeshassociation/extension-ui": "npm:2.1.0"
     browser-resolve: "npm:^2.0.0"
     buffer: "npm:^6.0.3"
     copy-webpack-plugin: "npm:^11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,7 +1450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:12.3.1, @polkadot/api-augment@npm:^12.3.1":
+"@polkadot/api-augment@npm:12.3.1":
   version: 12.3.1
   resolution: "@polkadot/api-augment@npm:12.3.1"
   dependencies:
@@ -2171,9 +2171,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polymeshassociation/extension-core@workspace:packages/core"
   dependencies:
-    "@polkadot/api-augment": "npm:^12.3.1"
+    "@polkadot/api-augment": "npm:12.3.1"
+    "@polkadot/types-codec": "npm:12.3.1"
     "@polkadot/ui-keyring": "npm:^3.8.3"
-    "@polymeshassociation/polymesh-types": "npm:^5.11.1"
+    "@polymeshassociation/polymesh-types": "npm:^5.15.0"
     "@reduxjs/toolkit": "npm:^1.9.7"
     "@types/crypto-js": "npm:^4.2.2"
     "@types/lodash-es": "npm:^4.17.12"
@@ -2268,9 +2269,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polymeshassociation/polymesh-sdk@npm:^26.0.0-beta.2":
-  version: 26.0.0-beta.2
-  resolution: "@polymeshassociation/polymesh-sdk@npm:26.0.0-beta.2"
+"@polymeshassociation/polymesh-sdk@npm:^27.0.0":
+  version: 27.0.0
+  resolution: "@polymeshassociation/polymesh-sdk@npm:27.0.0"
   dependencies:
     "@apollo/client": "npm:^3.8.1"
     "@polkadot/api": "npm:11.2.1"
@@ -2285,17 +2286,16 @@ __metadata:
     iso-7064: "npm:^1.1.0"
     json-stable-stringify: "npm:^1.0.2"
     lodash: "npm:^4.17.21"
-    patch-package: "npm:^8.0.0"
     semver: "npm:^7.5.4"
     websocket: "npm:^1.0.34"
-  checksum: 10c0/4d4065328aeefa4b947fde8e8d037024b7af38283a5117651c043c3ef509a34520b52ee91487157b8a17a87a18a58e011f85ab39a03e1512afb40ed0d5947c6a
+  checksum: 10c0/e132a9ac3ec77f52f9ef6993aff183e7d6674133f14813375fc4bd472faa38c1d320dcd52f8072b75e07fa691443d77ff53df96d5b62d4c1e35596f512ec24f4
   languageName: node
   linkType: hard
 
-"@polymeshassociation/polymesh-types@npm:^5.11.1":
-  version: 5.11.1
-  resolution: "@polymeshassociation/polymesh-types@npm:5.11.1"
-  checksum: 10c0/5647c177832f9256f43d1b342e7a4a3a879447558deccc7569bcf0c606056b96eb71d974c400fe746e41aeeb2c6f42aa29f6550aa1a8d2dbd94e3906e2b2dc6b
+"@polymeshassociation/polymesh-types@npm:^5.15.0":
+  version: 5.15.0
+  resolution: "@polymeshassociation/polymesh-types@npm:5.15.0"
+  checksum: 10c0/7e373fb96f6d974a4405cd220fa73643d5ac06cc7022ec9152a602547290ce01caf427328ce706e76ccff10a3abe4c86cb35247ac8d2acc2e9a582dc09451102
   languageName: node
   linkType: hard
 
@@ -4296,13 +4296,6 @@ __metadata:
   version: 4.2.2
   resolution: "@xtuc/long@npm:4.2.2"
   checksum: 10c0/8582cbc69c79ad2d31568c412129bf23d2b1210a1dfb60c82d5a1df93334da4ee51f3057051658569e2c196d8dc33bc05ae6b974a711d0d16e801e1d0647ccd1
-  languageName: node
-  linkType: hard
-
-"@yarnpkg/lockfile@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@yarnpkg/lockfile@npm:1.1.0"
-  checksum: 10c0/0bfa50a3d756623d1f3409bc23f225a1d069424dbc77c6fd2f14fb377390cd57ec703dc70286e081c564be9051ead9ba85d81d66a3e68eeb6eb506d4e0c0fbda
   languageName: node
   linkType: hard
 
@@ -6442,7 +6435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -6551,13 +6544,6 @@ __metadata:
   version: 2.0.0
   resolution: "ci-info@npm:2.0.0"
   checksum: 10c0/8c5fa3830a2bcee2b53c2e5018226f0141db9ec9f7b1e27a5c57db5512332cde8a0beb769bcbaf0d8775a78afbf2bb841928feca4ea6219638a5b088f9884b46
-  languageName: node
-  linkType: hard
-
-"ci-info@npm:^3.7.0":
-  version: 3.9.0
-  resolution: "ci-info@npm:3.9.0"
-  checksum: 10c0/6f0109e36e111684291d46123d491bc4e7b7a1934c3a20dea28cba89f1d4a03acd892f5f6a81ed3855c38647e285a150e3c9ba062e38943bef57fee6c1554c3a
   languageName: node
   linkType: hard
 
@@ -9716,15 +9702,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-yarn-workspace-root@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "find-yarn-workspace-root@npm:2.0.0"
-  dependencies:
-    micromatch: "npm:^4.0.2"
-  checksum: 10c0/b0d3843013fbdaf4e57140e0165889d09fa61745c9e85da2af86e54974f4cc9f1967e40f0d8fc36a79d53091f0829c651d06607d552582e53976f3cd8f4e5689
-  languageName: node
-  linkType: hard
-
 "findup-sync@npm:^4.0.0":
   version: 4.0.0
   resolution: "findup-sync@npm:4.0.0"
@@ -9877,7 +9854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:9.1.0, fs-extra@npm:^9.0.0":
+"fs-extra@npm:9.1.0":
   version: 9.1.0
   resolution: "fs-extra@npm:9.1.0"
   dependencies:
@@ -10488,17 +10465,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.6":
-  version: 4.2.11
-  resolution: "graceful-fs@npm:4.2.11"
-  checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
-  languageName: node
-  linkType: hard
-
 "graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 10c0/4223a833e38e1d0d2aea630c2433cfb94ddc07dfc11d511dbd6be1d16688c5be848acc31f9a5d0d0ddbfb56d2ee5a6ae0278aceeb0ca6a13f27e06b9956fb952
+  languageName: node
+  linkType: hard
+
+"graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.6":
+  version: 4.2.11
+  resolution: "graceful-fs@npm:4.2.11"
+  checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
   languageName: node
   linkType: hard
 
@@ -11855,7 +11832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-wsl@npm:^2.1.1, is-wsl@npm:^2.2.0":
+"is-wsl@npm:^2.2.0":
   version: 2.2.0
   resolution: "is-wsl@npm:2.2.0"
   dependencies:
@@ -12822,15 +12799,6 @@ __metadata:
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
   checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
-  languageName: node
-  linkType: hard
-
-"klaw-sync@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "klaw-sync@npm:6.0.0"
-  dependencies:
-    graceful-fs: "npm:^4.1.11"
-  checksum: 10c0/00d8e4c48d0d699b743b3b028e807295ea0b225caf6179f51029e19783a93ad8bb9bccde617d169659fbe99559d73fb35f796214de031d0023c26b906cecd70a
   languageName: node
   linkType: hard
 
@@ -14252,16 +14220,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^7.4.2":
-  version: 7.4.2
-  resolution: "open@npm:7.4.2"
-  dependencies:
-    is-docker: "npm:^2.0.0"
-    is-wsl: "npm:^2.1.1"
-  checksum: 10c0/77573a6a68f7364f3a19a4c80492712720746b63680ee304555112605ead196afe91052bd3c3d165efdf4e9d04d255e87de0d0a77acec11ef47fd5261251813f
-  languageName: node
-  linkType: hard
-
 "open@npm:^8.0.9":
   version: 8.4.2
   resolution: "open@npm:8.4.2"
@@ -14586,31 +14544,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"patch-package@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "patch-package@npm:8.0.0"
-  dependencies:
-    "@yarnpkg/lockfile": "npm:^1.1.0"
-    chalk: "npm:^4.1.2"
-    ci-info: "npm:^3.7.0"
-    cross-spawn: "npm:^7.0.3"
-    find-yarn-workspace-root: "npm:^2.0.0"
-    fs-extra: "npm:^9.0.0"
-    json-stable-stringify: "npm:^1.0.2"
-    klaw-sync: "npm:^6.0.0"
-    minimist: "npm:^1.2.6"
-    open: "npm:^7.4.2"
-    rimraf: "npm:^2.6.3"
-    semver: "npm:^7.5.3"
-    slash: "npm:^2.0.0"
-    tmp: "npm:^0.0.33"
-    yaml: "npm:^2.2.2"
-  bin:
-    patch-package: index.js
-  checksum: 10c0/690eab0537e953a3fd7d32bb23f0e82f97cd448f8244c3227ed55933611a126f9476397325c06ad2c11d881a19b427a02bd1881bee78d89f1731373fc4fe0fee
-  languageName: node
-  linkType: hard
-
 "path-browserify@npm:^1.0.1":
   version: 1.0.1
   resolution: "path-browserify@npm:1.0.1"
@@ -14811,7 +14744,7 @@ __metadata:
     "@polkadot/dev": "npm:^0.79.3"
     "@polkadot/dev-test": "npm:^0.79.3"
     "@polkadot/types": "npm:^12.3.1"
-    "@polymeshassociation/polymesh-sdk": "npm:^26.0.0-beta.2"
+    "@polymeshassociation/polymesh-sdk": "npm:^27.0.0"
     "@semantic-release/changelog": "npm:^6.0.3"
     "@semantic-release/exec": "npm:^6.0.3"
     "@semantic-release/git": "npm:^10.0.1"
@@ -16145,17 +16078,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^2.6.3":
-  version: 2.7.1
-  resolution: "rimraf@npm:2.7.1"
-  dependencies:
-    glob: "npm:^7.1.3"
-  bin:
-    rimraf: ./bin.js
-  checksum: 10c0/4eef73d406c6940927479a3a9dee551e14a54faf54b31ef861250ac815172bade86cc6f7d64a4dc5e98b65e4b18a2e1c9ff3b68d296be0c748413f092bb0dd40
-  languageName: node
-  linkType: hard
-
 "rimraf@npm:^3.0.0, rimraf@npm:^3.0.2":
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
@@ -16863,13 +16785,6 @@ __metadata:
   version: 1.0.0
   resolution: "slash@npm:1.0.0"
   checksum: 10c0/3944659885d905480f98810542fd314f3e1006eaad25ec78227a7835a469d9ed66fc3dd90abc7377dd2e71f4b5473e8f766bd08198fdd25152a80792e9ed464c
-  languageName: node
-  linkType: hard
-
-"slash@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "slash@npm:2.0.0"
-  checksum: 10c0/f83dbd3cb62c41bb8fcbbc6bf5473f3234b97fa1d008f571710a9d3757a28c7169e1811cad1554ccb1cc531460b3d221c9a7b37f549398d9a30707f0a5af9193
   languageName: node
   linkType: hard
 
@@ -19307,15 +19222,6 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 10c0/5c28b9eb7adc46544f28d9a8d20c5b3cb1215a886609a2fd41f51628d8aaa5878ccd628b755dbcd29f6bb4921bd04ffbc6dcc370689bb96e594e2f9813d2605f
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^2.2.2":
-  version: 2.4.5
-  resolution: "yaml@npm:2.4.5"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/e1ee78b381e5c710f715cc4082fd10fc82f7f5c92bd6f075771d20559e175616f56abf1c411f545ea0e9e16e4f84a83a50b42764af5f16ec006328ba9476bb31
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,7 +2167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polymeshassociation/extension-core@npm:2.0.1, @polymeshassociation/extension-core@workspace:packages/core":
+"@polymeshassociation/extension-core@npm:2.0.2, @polymeshassociation/extension-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@polymeshassociation/extension-core@workspace:packages/core"
   dependencies:
@@ -2192,7 +2192,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polymeshassociation/extension-ui@npm:2.0.1, @polymeshassociation/extension-ui@workspace:packages/ui":
+"@polymeshassociation/extension-ui@npm:2.0.2, @polymeshassociation/extension-ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@polymeshassociation/extension-ui@workspace:packages/ui"
   dependencies:
@@ -2246,8 +2246,8 @@ __metadata:
     "@polkadot/extension-base": "npm:^0.51.1"
     "@polkadot/extension-inject": "npm:^0.51.1"
     "@polkadot/ui-keyring": "npm:^3.8.3"
-    "@polymeshassociation/extension-core": "npm:2.0.1"
-    "@polymeshassociation/extension-ui": "npm:2.0.1"
+    "@polymeshassociation/extension-core": "npm:2.0.2"
+    "@polymeshassociation/extension-ui": "npm:2.0.2"
     browser-resolve: "npm:^2.0.0"
     buffer: "npm:^6.0.3"
     copy-webpack-plugin: "npm:^11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,7 +2167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polymeshassociation/extension-core@npm:1.8.3, @polymeshassociation/extension-core@workspace:packages/core":
+"@polymeshassociation/extension-core@npm:2.0.1, @polymeshassociation/extension-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@polymeshassociation/extension-core@workspace:packages/core"
   dependencies:
@@ -2192,7 +2192,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polymeshassociation/extension-ui@npm:1.8.3, @polymeshassociation/extension-ui@workspace:packages/ui":
+"@polymeshassociation/extension-ui@npm:2.0.1, @polymeshassociation/extension-ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@polymeshassociation/extension-ui@workspace:packages/ui"
   dependencies:
@@ -2246,8 +2246,8 @@ __metadata:
     "@polkadot/extension-base": "npm:^0.51.1"
     "@polkadot/extension-inject": "npm:^0.51.1"
     "@polkadot/ui-keyring": "npm:^3.8.3"
-    "@polymeshassociation/extension-core": "npm:1.8.3"
-    "@polymeshassociation/extension-ui": "npm:1.8.3"
+    "@polymeshassociation/extension-core": "npm:2.0.1"
+    "@polymeshassociation/extension-ui": "npm:2.0.1"
     browser-resolve: "npm:^2.0.0"
     buffer: "npm:^6.0.3"
     copy-webpack-plugin: "npm:^11.0.0"


### PR DESCRIPTION
- When signing if a the wallet is missing permissions to connect to a ledger over USB display
![image](https://github.com/user-attachments/assets/14b1c58b-49f1-4abd-a023-74412bf70b35)
After opening the extension in a window clicking the connect button will trigger the permissioning flow for the USB device. 
![image](https://github.com/user-attachments/assets/2c3e51c2-e93c-4c2a-9242-eeb293bc1729)
Permissioning must be triggered by a user action requiring them to explicitly click connect.

- Fix showing protocol fees for `AssetRegisterUniqueTicker`
- Show protocol fees for nested calls
- Update to lastest Polymesh SDK and types bundles
- Add SignedExtension definitions when calling registry.setSignedExtensions to prevent the unknown signedExtension StoreCall Metadata warning.
- Update `PolymeshInjected` so it will no longer trigger an ongoing ping message which was causing console errors after not interacting with a dApp for a period of time. 
- Fix loading spinner