### PR TITLE
Automatically refresh metadata and Clean up stale subscriptions

### DIFF
--- a/packages/core/src/background/handlers/Extension.ts
+++ b/packages/core/src/background/handlers/Extension.ts
@@ -1,14 +1,15 @@
 /* global chrome */
 
 import type { MessageTypes, RequestRpcUnsubscribe, ResponseType } from '@polkadot/extension-base/background/types';
+import type { MetadataDef } from '@polkadot/extension-inject/types';
 import type { KeyringPair } from '@polkadot/keyring/types';
-import type { AllowedPath, PolyMessageTypes, PolyRequestTypes, PolyResponseType, RequestPolyCallDetails, RequestPolyCustomNetworkUrlSet, RequestPolyGlobalChangePass, RequestPolyIdentityRename, RequestPolyNetworkSet, RequestPolySelectedAccountSet, RequestPolyValidatePassword, ResponsePolyCallDetails } from '../types';
+import type { AllowedPath, PolyMessageTypes, PolyRequestTypes, PolyResponseType, RequestPolyCallDetails, RequestPolyCustomNetworkUrlSet, RequestPolyGlobalChangePass, RequestPolyIdentityRename, RequestPolyMetadataRefresh, RequestPolyNetworkSet, RequestPolySelectedAccountSet, RequestPolyValidatePassword, ResponsePolyCallDetails } from '../types';
 
 import { withErrorLog } from '@polkadot/extension-base/background';
 import DotExtension from '@polkadot/extension-base/background/handlers/Extension';
 import keyring from '@polkadot/ui-keyring';
 
-import { callDetails } from '@polymeshassociation/extension-core/external';
+import { callDetails, refreshMetadata } from '@polymeshassociation/extension-core/external';
 import { getNetworkUrl } from '@polymeshassociation/extension-core/store/getters';
 import { renameIdentity, setCustomNetworkUrl, setNetwork, setSelectedAccount, toggleIsDeveloper } from '@polymeshassociation/extension-core/store/setters';
 import { subscribeIdentifiedAccounts, subscribeNetworkState, subscribeSelectedAccount, subscribeSelectedNetwork, subscribeStatus } from '@polymeshassociation/extension-core/store/subscribers';
@@ -130,6 +131,10 @@ export default class Extension extends DotExtension {
     const networkUrl = getNetworkUrl();
 
     return callDetails(request, networkUrl);
+  }
+
+  private polyMetadataRefresh ({ genesisHash }: RequestPolyMetadataRefresh): Promise<MetadataDef | null> {
+    return refreshMetadata(genesisHash);
   }
 
   private polyIsDevToggle (): boolean {
@@ -286,6 +291,9 @@ export default class Extension extends DotExtension {
 
       case 'poly:pri(callDetails.get)':
         return this.polyCallDetailsGet(request as RequestPolyCallDetails);
+
+      case 'poly:pri(metadata.refresh)':
+        return this.polyMetadataRefresh(request as RequestPolyMetadataRefresh);
 
       case 'poly:pri(status.subscribe)':
         return port && this.polyStoreStatusSubscribe(id, port);

--- a/packages/core/src/background/types.ts
+++ b/packages/core/src/background/types.ts
@@ -1,4 +1,5 @@
 import type { RequestSignatures as DotRequestSignatures } from '@polkadot/extension-base/background/types';
+import type { MetadataDef } from '@polkadot/extension-inject/types';
 import type { FunctionMetadataLatest } from '@polkadot/types/interfaces';
 import type { AnyJson, SignerPayloadJSON } from '@polkadot/types/types';
 import type { HexString } from '@polkadot/util/types';
@@ -89,6 +90,10 @@ export interface RequestPolyGlobalChangePass {
   newPass: string;
 }
 
+export interface RequestPolyMetadataRefresh {
+  genesisHash: string;
+}
+
 export interface PolyRequestSignatures extends DotRequestSignatures {
   // private/internal requests, i.e. from a popup
   'poly:pri(accounts.subscribe)': [ RequestPolyAccountsSubscribe, boolean, IdentifiedAccount[] ];
@@ -107,6 +112,7 @@ export interface PolyRequestSignatures extends DotRequestSignatures {
   'poly:pri(password.isSet)': [RequestPolyIsPasswordSet, boolean];
   'poly:pri(password.validate)': [RequestPolyValidatePassword, boolean];
   'poly:pri(window.open)': [AllowedPath, boolean];
+  'poly:pri(metadata.refresh)': [RequestPolyMetadataRefresh, MetadataDef | null];
   // public/external requests, i.e. from a page
   'poly:pub(network.get)': [RequestPolyNetworkGet, NetworkMeta];
   'poly:pub(network.subscribe)': [ RequestPolyNetworkMetaSubscribe, string, NetworkMeta ];

--- a/packages/core/src/external/apiPromise/index.ts
+++ b/packages/core/src/external/apiPromise/index.ts
@@ -115,6 +115,48 @@ async function apiPromise (networkUrl: string): Promise<ApiPromise> {
   return api;
 }
 
+export async function refreshMetadata (genesisHash: string): Promise<MetadataDef | null> {
+  if (!api || !provider?.isConnected) {
+    return null;
+  }
+
+  if (api.genesisHash.toHex() !== genesisHash) {
+    return null;
+  }
+
+  try {
+    // The polkadot-js API subscribes to runtime version changes internally and
+    // keeps api.runtimeMetadata / api.runtimeVersion up-to-date automatically,
+    // so no extra RPC call is needed here.
+    const rawMetadata = api.runtimeMetadata.toHex();
+    const specVersion = api.runtimeVersion.specVersion.toNumber();
+    const key = `${genesisHash}-${specVersion}`;
+
+    const def: MetadataDef = {
+      chain: api.runtimeChain.toString(),
+      genesisHash,
+      icon: 'substrate',
+      rawMetadata,
+      specVersion,
+      ss58Format: api.registry.chainSS58 ?? 42,
+      tokenDecimals: api.registry.chainDecimals[0] ?? 6,
+      tokenSymbol: api.registry.chainTokens[0] ?? 'POLYX',
+      types: {},
+      userExtensions: polymeshSignedExtensions
+    };
+
+    metadata[key] = rawMetadata;
+    addMetadata(def);
+    await metaStore.set(genesisHash, def);
+
+    return def;
+  } catch (error) {
+    console.error('Failed to refresh metadata from chain:', error);
+
+    return null;
+  }
+}
+
 export async function disconnect (): Promise<void> {
   if (api) {
     try {

--- a/packages/core/src/external/index.ts
+++ b/packages/core/src/external/index.ts
@@ -1,5 +1,5 @@
-import apiPromise from './apiPromise';
+import apiPromise, { refreshMetadata } from './apiPromise';
 import callDetails from './callDetails';
 import polyNetworkGet from './polyNetworkGet';
 
-export { apiPromise, callDetails, polyNetworkGet };
+export { apiPromise, callDetails, polyNetworkGet, refreshMetadata };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,6 +138,20 @@ const initApiPromise = (network: NetworkName, networkUrl: string) =>
       let prevAccounts: string[] = [];
 
       const subscribeAccounts = (activeIssuers: Set<string>) => {
+        // Flush any per-account chain subscriptions left over from a previous network
+        // connection. prevAccounts resets to [] on each initApiPromise call, so the
+        // observeAccounts callback would never clean these up on its first fire,
+        // allowing stale queryMulti callbacks to dispatch wrong-chain data.
+        for (const key in accountUnsubCallbacks) {
+          try {
+            accountUnsubCallbacks[key]?.();
+          } catch (e) {
+            console.error(e);
+          }
+
+          delete accountUnsubCallbacks[key];
+        }
+
         /**
          * Accounts
          */
@@ -186,6 +200,10 @@ const initApiPromise = (network: NetworkName, networkUrl: string) =>
                     FrameSystemAccountInfo,
                     Option<PolymeshPrimitivesSecondaryKeyKeyRecord>
                   ]) => {
+                    if (network !== getNetwork()) {
+                      return;
+                    }
+
                     // Store account metadata
                     const { locked, total, transferrable } = accountBalances(
                       accData.data,
@@ -248,6 +266,10 @@ const initApiPromise = (network: NetworkName, networkUrl: string) =>
                           linkedKeyInfoObj.asMultiSigSignerKey
                         ));
 
+                      if (network !== getNetwork()) {
+                        return;
+                      }
+
                       if (msLinkedKeyInfo?.isEmpty) {
                         // Signer key can point to a multisig that is no longer linked to a DID.
                         store.dispatch(
@@ -306,6 +328,11 @@ const initApiPromise = (network: NetworkName, networkUrl: string) =>
                           target: did
                         }
                       );
+
+                      if (network !== getNetwork()) {
+                        return;
+                      }
+
                       const cddData = claimData
                         .map(([, claim]) => claim)
                         .filter((claim) => !claim.isEmpty)
@@ -423,6 +450,9 @@ function subscribePolymesh (): () => void {
         if (network) {
           console.log('Poly: Selected network', network);
           store.dispatch(statusActions.init());
+          // Eagerly clear stale identity mappings so the UI never shows
+          // previous-network identity data while waiting for the first new callbacks.
+          store.dispatch(identityActions.clearCurrentIdentities());
           const networkUrl = getNetworkUrl();
 
           await initApiPromise(network, networkUrl);
@@ -446,6 +476,8 @@ function subscribePolymesh (): () => void {
       if (customNetworkUrl && !firstCall) {
         console.log('Poly: Custom rpc url', customNetworkUrl);
         store.dispatch(statusActions.init());
+        // Eagerly clear stale identity mappings (mirrors network-switch handler).
+        store.dispatch(identityActions.clearCurrentIdentities());
         const network = getNetwork();
 
         await initApiPromise(network, customNetworkUrl);

--- a/packages/ui/src/Popup/Signing/Extrinsic.tsx
+++ b/packages/ui/src/Popup/Signing/Extrinsic.tsx
@@ -32,8 +32,9 @@ interface DecodedCall {
 
 function Extrinsic ({ onFeeStateChange, onWarningStateChange, payloadExt, request }: Props): React.ReactElement<Props> {
   const { networkState } = useContext(PolymeshContext);
-  const { chain, isLoading: isMetadataLoading } = useMetadata(request.genesisHash);
   const requestSpec = useMemo(() => hexToBn(request.specVersion), [request.specVersion]);
+  const requestSpecNumber = useMemo(() => requestSpec.toNumber(), [requestSpec]);
+  const { chain, isLoading: isMetadataLoading } = useMetadata(request.genesisHash, false, requestSpecNumber);
   const [networkFee, setNetworkFee] = useState('');
   const [protocolFee, setProtocolFee] = useState('');
   const [feeLoading, setFeeLoading] = useState(false);

--- a/packages/ui/src/Popup/Signing/LedgerSignArea.tsx
+++ b/packages/ui/src/Popup/Signing/LedgerSignArea.tsx
@@ -103,14 +103,15 @@ function LedgerSignArea ({ accountIndex,
     signingChannel.postMessage('signing-end');
   }, [signingChannel]);
 
-  const { chain } = useMetadata(genesisHash);
   // Read specVersion directly from the payload (always available) so the correct app is
   // selected immediately without waiting for useMetadata to resolve asynchronously.
   // hexToNumber returns NaN for invalid input; fall back to chain?.specVersion in that case.
   const payloadSpecVersion = payloadJson ? hexToNumber(payloadJson.specVersion) : undefined;
-  const specVersion = (payloadSpecVersion !== undefined && !Number.isNaN(payloadSpecVersion))
+  const requestedSpecVersion = (payloadSpecVersion !== undefined && !Number.isNaN(payloadSpecVersion))
     ? payloadSpecVersion
-    : chain?.specVersion;
+    : undefined;
+  const { chain } = useMetadata(genesisHash, false, requestedSpecVersion);
+  const specVersion = requestedSpecVersion ?? chain?.specVersion;
   const { address: ledgerAddress,
     error: ledgerError,
     isLoading: ledgerLoading,

--- a/packages/ui/src/hooks/useMetadata.ts
+++ b/packages/ui/src/hooks/useMetadata.ts
@@ -2,14 +2,14 @@ import type { Chain } from '@polkadot/extension-chains/types';
 
 import { useEffect, useState } from 'react';
 
-import { getMetadata } from '../messaging';
+import { getMetadata, refreshMetadataFromChain } from '../messaging';
 
 interface UseMetadataResult {
   chain: Chain | null;
   isLoading: boolean;
 }
 
-export default function useMetadata (genesisHash?: string | null, isPartial?: boolean): UseMetadataResult {
+export default function useMetadata (genesisHash?: string | null, isPartial?: boolean, requestedSpecVersion?: number): UseMetadataResult {
   const [chain, setChain] = useState<Chain | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -20,10 +20,26 @@ export default function useMetadata (genesisHash?: string | null, isPartial?: bo
       setChain(null);
       setIsLoading(true);
 
-      getMetadata(genesisHash, isPartial)
-        .then((storedChain): void => {
+      const fetchChain = async (): Promise<Chain | null> => {
+        const storedChain = await getMetadata(genesisHash, isPartial);
+
+        // When a specVersion is provided and the stored metadata is outdated,
+        // try refreshing directly from the connected chain before giving up.
+        if (
+          requestedSpecVersion !== undefined &&
+          storedChain !== null &&
+          storedChain.specVersion !== requestedSpecVersion
+        ) {
+          return refreshMetadataFromChain(genesisHash, isPartial);
+        }
+
+        return storedChain;
+      };
+
+      fetchChain()
+        .then((resolvedChain): void => {
           if (!isCancelled) {
-            setChain(storedChain);
+            setChain(resolvedChain);
           }
         })
         .catch((error): void => {
@@ -46,7 +62,7 @@ export default function useMetadata (genesisHash?: string | null, isPartial?: bo
     return (): void => {
       isCancelled = true;
     };
-  }, [genesisHash, isPartial]);
+  }, [genesisHash, isPartial, requestedSpecVersion]);
 
   return { chain, isLoading };
 }

--- a/packages/ui/src/messaging.ts
+++ b/packages/ui/src/messaging.ts
@@ -223,6 +223,26 @@ export async function getMetadata (genesisHash?: string | null, isPartial = fals
   return null;
 }
 
+// Fetch fresh metadata from the connected chain, update the background store,
+// and return the expanded Chain. Used when cached metadata has a stale specVersion
+// (e.g. after a runtime upgrade without a wallet restart).
+export async function refreshMetadataFromChain (genesisHash: string, isPartial = false): Promise<Chain | null> {
+  let def: MetadataDef | null = null;
+
+  try {
+    def = await sendMessage('poly:pri(metadata.refresh)', { genesisHash });
+
+    return def ? metadataExpand(def, isPartial) : null;
+  } finally {
+    // Clear cached getMetadata promise so subsequent calls don't reuse stale data.
+    clearSavedMeta(genesisHash);
+
+    if (def) {
+      setSavedMeta(genesisHash, Promise.resolve(def));
+    }
+  }
+}
+
 export async function getConnectedTabsUrl (): Promise<ConnectedTabsUrlResponse> {
   return sendMessage('pri(connectedTabsUrl.get)', null);
 }


### PR DESCRIPTION
- Automatically try to refresh metadata if the stored chain spec doesn't match the transaction chain spec. This ensure seemless transactoin handling across chain upgrades
- Unsubscribe from accounts and identities on network chains to prevent stale/incorrect data after changing networks.